### PR TITLE
feat: add Linux-safe support (manual cert trust, start.sh, cross-platform proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ This project is designed to facilitate the use of Warp.dev. No responsibility is
 
 ## Usage Video:
 https://youtu.be/5_itpYHZGJc
+
+## Linux Support
+
+This fork adds safer Linux support:
+
+- Windows-specific registry and certificate installation are gated. On Linux, mitmproxy certificate trust is manual.
+- Use `start.sh` to install dependencies and run the app.
+- After first run, trust `~/.mitmproxy/mitmproxy-ca-cert.pem` in your browser/system trust store to allow HTTPS interception.
+- Set your browser/system proxy to `127.0.0.1:8080` when activating an account.
+
+Steps (Linux):
+
+1. `bash start.sh`
+2. Manually trust `~/.mitmproxy/mitmproxy-ca-cert.pem` in your browser.
+3. Set proxy to `127.0.0.1:8080` while using Warp (the app shows a reminder).
+4. Use the GUI to add accounts (Chrome extension or manual JSON) and activate.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Warp Account Manager - Linux setup/start"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found. Install Python 3.8+" >&2
+  exit 1
+fi
+
+if ! command -v pip3 >/dev/null 2>&1; then
+  echo "ERROR: pip3 not found. Install pip for Python3" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "==> Ensuring dependencies"
+pip3 install -r requirements.txt
+
+echo "==> Note: mitmproxy certificate trust is manual on Linux"
+echo "    The certificate file is at ~/.mitmproxy/mitmproxy-ca-cert.pem after first run."
+echo "    Trust it in your browser/system cert store to allow HTTPS interception."
+
+echo "==> Starting Warp Account Manager"
+exec python3 warp_account_manager.py
+
+


### PR DESCRIPTION
This PR adds Linux-safe support:
- Gate Windows-only imports and registry/cert steps.
- Linux cert handling: ~/.mitmproxy/mitmproxy-ca-cert.pem, manual trust.
- Dynamic X-Warp-Os headers and osContext for Linux.
- start.sh helper for Linux users. 
- Cross-platform subprocess flags and xdg-open.

Tested: Linux venv install; app launches (PyQt5+mitmproxy).