### PR TITLE
feat(macos): Add bridge and proxy configuration support for macOS

### DIFF
--- a/macos_bridge_config.py
+++ b/macos_bridge_config.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+macOS Bridge Configuration - Native messaging setup for Chrome extension
+"""
+
+import os
+import sys
+import json
+from pathlib import Path
+
+
+class MacOSBridgeConfig:
+    def __init__(self):
+        self.extension_id = "warp-account-bridge-v1"
+        self.app_name = "com.warp.account.bridge"
+        self.native_messaging_dir = Path.home() / "Library/Application Support/Google/Chrome/NativeMessagingHosts"
+
+    def is_admin(self):
+        """Check if running as administrator (root)"""
+        return os.getuid() == 0
+
+    def setup_localhost_access(self):
+        """Configure macOS for localhost access from extensions"""
+        try:
+            print("🔧 Chrome extension manifest localhost access...")
+
+            # Chrome extension uses externally_connectable in manifest
+            # No additional macOS-specific registry settings needed
+            print("✅ Manifest-based localhost access active")
+            print("📋 Extension manifest has externally_connectable configuration")
+
+            return True
+
+        except Exception as e:
+            print(f"❌ Localhost access setup error: {e}")
+            return False
+
+    def create_native_messaging_manifest(self):
+        """Create native messaging host manifest for macOS"""
+        try:
+            # Python executable path
+            python_exe = sys.executable
+            script_path = os.path.abspath("warp_account_manager.py")
+
+            manifest = {
+                "name": self.app_name,
+                "description": "Warp Account Bridge Native Host",
+                "path": python_exe,
+                "type": "stdio",
+                "allowed_origins": [
+                    f"chrome-extension://{self.extension_id}/"
+                ]
+            }
+
+            # Create manifest directory if it doesn't exist
+            self.native_messaging_dir.mkdir(parents=True, exist_ok=True)
+
+            manifest_path = self.native_messaging_dir / f"{self.app_name}.json"
+            with open(manifest_path, 'w') as f:
+                json.dump(manifest, f, indent=2)
+
+            print(f"✅ Native messaging manifest created: {manifest_path}")
+            return str(manifest_path)
+
+        except Exception as e:
+            print(f"❌ Manifest creation error: {e}")
+            return None
+
+    def register_native_host(self):
+        """Register native messaging host (macOS uses file-based registration)"""
+        try:
+            manifest_path = self.create_native_messaging_manifest()
+            if not manifest_path:
+                return False
+
+            print(f"✅ Native host registered: {manifest_path}")
+            return True
+
+        except Exception as e:
+            print(f"❌ Native host registration error: {e}")
+            return False
+
+    def setup_bridge_config(self):
+        """Complete bridge configuration for macOS"""
+        print("🌉 macOS Bridge configuration starting...")
+
+        # 1. Localhost access setup
+        localhost_ok = self.setup_localhost_access()
+
+        # 2. Native messaging host registration
+        native_ok = self.register_native_host()
+
+        if localhost_ok and native_ok:
+            print("✅ Bridge configuration completed!")
+            print("\n📋 Next steps:")
+            print("1. Restart Chrome")
+            print("2. Load extension from chrome://extensions/ page")
+            print("3. Start Warp Account Manager")
+            return True
+        else:
+            print("❌ Bridge configuration failed!")
+            return False
+
+    def check_configuration(self):
+        """Check if bridge is properly configured"""
+        try:
+            print("🔍 Checking bridge configuration...")
+
+            # Check if manifest file exists
+            manifest_path = self.native_messaging_dir / f"{self.app_name}.json"
+            if manifest_path.exists():
+                print("✅ Native messaging manifest found")
+                return True
+            else:
+                print("❌ Native messaging manifest not found")
+                return False
+
+        except Exception as e:
+            print(f"❌ Configuration check error: {e}")
+            return False
+
+    def remove_configuration(self):
+        """Remove bridge configuration (cleanup)"""
+        try:
+            print("🧹 Cleaning up bridge configuration...")
+
+            # Remove manifest file
+            manifest_path = self.native_messaging_dir / f"{self.app_name}.json"
+            if manifest_path.exists():
+                manifest_path.unlink()
+                print("✅ Manifest file removed")
+            else:
+                print("⚠️  Manifest file not found")
+
+            return True
+
+        except Exception as e:
+            print(f"❌ Cleanup error: {e}")
+            return False
+
+
+def setup_bridge():
+    """Setup bridge configuration"""
+    config = MacOSBridgeConfig()
+    return config.setup_bridge_config()
+
+def check_bridge():
+    """Check bridge configuration"""
+    config = MacOSBridgeConfig()
+    return config.check_configuration()
+
+def remove_bridge():
+    """Remove bridge configuration"""
+    config = MacOSBridgeConfig()
+    return config.remove_configuration()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        action = sys.argv[1]
+
+        if action == "setup":
+            setup_bridge()
+        elif action == "check":
+            check_bridge()
+        elif action == "remove":
+            remove_bridge()
+        else:
+            print("Usage: python macos_bridge_config.py [setup|check|remove]")
+    else:
+        # Default: setup
+        setup_bridge()

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# Warp Account Manager Launcher - macOS Edition
+# Automatic installation and startup script
+
+# Colors for better output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Clear screen and show header
+clear
+echo
+echo "===================================================="
+echo "   Warp Account Manager - Automatic Installation"
+echo "===================================================="
+echo
+
+# Function to print status messages
+print_status() {
+    echo -e "${GREEN}[OK]${NC} $1"
+}
+
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+# Navigate to script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+# Check if running as root (administrator equivalent)
+echo "[1/6] Checking permissions..."
+if [[ $EUID -eq 0 ]]; then
+    print_warning "Running as root - this is not recommended for this application"
+    print_info "You may run this script as a regular user"
+else
+    print_status "Running as regular user"
+fi
+echo
+
+# Check if Python is installed
+echo "[2/6] Checking Python installation..."
+if command -v python3 &> /dev/null; then
+    PYTHON_VERSION=$(python3 --version 2>&1 | cut -d' ' -f2)
+    print_status "Python $PYTHON_VERSION found"
+    PYTHON_CMD="python3"
+elif command -v python &> /dev/null; then
+    PYTHON_VERSION=$(python --version 2>&1 | cut -d' ' -f2)
+    # Check if it's Python 3
+    if python -c "import sys; exit(0 if sys.version_info[0] >= 3 else 1)" 2>/dev/null; then
+        print_status "Python $PYTHON_VERSION found"
+        PYTHON_CMD="python"
+    else
+        print_error "Python 3.8 or higher is required, but found Python 2"
+        echo
+        echo "Please install Python 3 using one of these methods:"
+        echo "1. Homebrew: brew install python3"
+        echo "2. Python.org: https://python.org"
+        echo "3. Pyenv: pyenv install 3.11"
+        echo
+        read -p "Press Enter to exit..."
+        exit 1
+    fi
+else
+    print_error "Python not found!"
+    echo
+    echo "Python 3.8 or higher is required."
+    echo "Please install Python using one of these methods:"
+    echo "1. Homebrew: brew install python3"
+    echo "2. Python.org: https://python.org"
+    echo "3. Pyenv: pyenv install 3.11"
+    echo
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+echo
+
+# Check if pip is installed
+echo "[3/6] Checking pip installation..."
+if command -v pip3 &> /dev/null; then
+    print_status "pip3 found"
+    PIP_CMD="pip3"
+elif command -v pip &> /dev/null; then
+    print_status "pip found"
+    PIP_CMD="pip"
+else
+    print_error "pip not found!"
+    echo
+    echo "pip should come with Python."
+    echo "Try reinstalling Python or install pip manually:"
+    echo "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+    echo "$PYTHON_CMD get-pip.py"
+    echo
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+echo
+
+# Check and install required packages
+echo "[4/6] Checking required Python packages..."
+echo
+
+# Package list
+PACKAGES=("PyQt5" "requests" "mitmproxy" "psutil")
+
+# Check each package
+for package in "${PACKAGES[@]}"; do
+    echo "  Checking: $package"
+    if $PIP_CMD show "$package" > /dev/null 2>&1; then
+        print_status "  $package already installed"
+    else
+        print_info "  [MISSING] Installing $package..."
+        
+        # Try different installation methods for macOS
+        if [[ "$package" == "PyQt5" ]]; then
+            # PyQt5 via Homebrew on macOS
+            if command -v brew &> /dev/null; then
+                echo "  Trying Homebrew installation for PyQt5..."
+                if brew install pyqt@5; then
+                    print_status "  $package successfully installed via Homebrew"
+                    continue
+                fi
+            fi
+        elif [[ "$package" == "mitmproxy" ]]; then
+            # mitmproxy via Homebrew (already should be installed)
+            if command -v mitmdump &> /dev/null; then
+                print_status "  mitmproxy already available via Homebrew"
+                continue
+            fi
+        fi
+        
+        # Try pip with --break-system-packages as fallback
+        if $PIP_CMD install "$package" --break-system-packages; then
+            print_status "  $package successfully installed"
+        else
+            print_error "  Failed to install $package!"
+            echo
+            echo "  Possible solutions:"
+            echo "  1. Install via Homebrew: brew install $package"
+            echo "  2. Create virtual environment"
+            echo "  3. Try: $PIP_CMD install --user $package --break-system-packages"
+            echo
+            read -p "Continue anyway? (y/N): " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                exit 1
+            fi
+        fi
+    fi
+done
+
+echo
+print_status "All required packages are ready"
+echo
+
+# Database file check
+echo "[5/6] Checking database file..."
+if [[ -f "accounts.db" ]]; then
+    print_status "Database file exists"
+else
+    print_info "Database file will be created"
+fi
+echo
+
+# Start Warp Account Manager
+echo "[6/6] Starting Warp Account Manager..."
+echo
+echo "===================================================="
+echo "   Installation completed - Starting application"
+echo "===================================================="
+echo
+
+if [[ -f "warp_account_manager.py" ]]; then
+    print_info "Opening Warp Account Manager..."
+    echo
+    print_warning "NOTE: Do not close this terminal window! This console window"
+    print_warning "      must remain open while the application is running."
+    echo
+    
+    # Start the application
+    $PYTHON_CMD warp_account_manager.py
+    
+    echo
+    print_info "Warp Account Manager closed."
+else
+    print_error "warp_account_manager.py file not found!"
+    echo
+    echo "Current directory: $(pwd)"
+    echo "Script directory: $SCRIPT_DIR"
+    echo
+    echo "Please ensure all files are in the correct location."
+fi
+
+echo
+echo "Press Enter to exit..."
+read

--- a/warp_proxy_script.py
+++ b/warp_proxy_script.py
@@ -322,6 +322,7 @@ def is_relevant_request(flow: http.HTTPFlow) -> bool:
         "dataplane.rudderstack.com"  # Bloklamak için
     ]
 
+    # Warp ile ilgili olmayan istekleri sessizce geçir (internet erişimini engelleme)
     if not any(domain in flow.request.pretty_host for domain in relevant_domains):
         return False
 
@@ -331,8 +332,9 @@ def is_relevant_request(flow: http.HTTPFlow) -> bool:
 def request(flow: http.HTTPFlow) -> None:
     """İstek yakalandığında çalışır"""
 
-    # İlgisiz istekleri hemen filtrele - sessizce geç
+    # İlgisiz istekleri hemen filtrele - sessizce geç (internet erişimine müdahale etme)
     if not is_relevant_request(flow):
+        # Warp ile ilgili olmayan tüm trafiği direkt geçir
         return
 
     request_url = flow.request.pretty_url
@@ -431,7 +433,7 @@ def response(flow: http.HTTPFlow) -> None:
     if "app.warp.dev" not in flow.request.pretty_host:
         return
 
-    # İlgisiz istekleri hemen filtrele - sessizce geç
+    # İlgisiz istekleri hemen filtrele - sessizce geç (internet erişimine müdahale etme)
     if not is_relevant_request(flow):
         return
 


### PR DESCRIPTION
- Implement macOSBridgeConfig for native messaging configuration
- Create start-macos.sh script for automatic installation and startup
- Adapt warp_account_manager.py to detect macOS and use new settings
- Add proxy management on macOS with PAC files for selective traffic
- Add methods to enable, disable, and verify proxies on macOS
- Improve mitmproxy certificate handling: verification and repair on macOS
- Update automatic certificate installation for macOS with multiple options
- Add specific checks for mitmproxy in macOS environments
- Improve mitmproxy process handling for multiple platforms and debug modes
- Provide recommendations based on common mitmproxy errors on macOS